### PR TITLE
ros_control: sort joints from config before pinging them

### DIFF
--- a/bitbots_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/bitbots_ros_control/src/dynamixel_hardware_interface.cpp
@@ -215,7 +215,6 @@ bool DynamixelHardwareInterface::loadDynamixels(ros::NodeHandle& nh)
   nh.param("read_effort", _read_effort, false);
 
 
-  int i = 0;
   XmlRpc::XmlRpcValue dxls_xml;
   nh.getParam("dynamixels/device_info", dxls_xml);
   ROS_ASSERT(dxls_xml.getType() == XmlRpc::XmlRpcValue::TypeStruct);
@@ -258,7 +257,6 @@ bool DynamixelHardwareInterface::loadDynamixels(ros::NodeHandle& nh)
     }
     array.push_back(createServoDiagMsg(motor_id, diagnostic_msgs::DiagnosticStatus::OK, "Ping sucessful", map));
     _joint_ids.push_back(uint8_t(motor_id));
-    i++;
   }
 
   _status_board.level = diagnostic_msgs::DiagnosticStatus::OK;

--- a/bitbots_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/bitbots_ros_control/src/dynamixel_hardware_interface.cpp
@@ -251,7 +251,7 @@ bool DynamixelHardwareInterface::loadDynamixels(ros::NodeHandle& nh)
 
     //ping it to very that it's there and to add it to the driver
     if(!_driver->ping(uint8_t(motor_id), model_number_16p)){
-      ROS_ERROR("Was not able to ping motor with id %d", motor_id);
+      ROS_ERROR("Was not able to ping motor with id %d (%s)", motor_id, dxl_name.c_str());
       success = false;
       array.push_back(createServoDiagMsg(motor_id, diagnostic_msgs::DiagnosticStatus::STALE, "No ping response", map));
     }


### PR DESCRIPTION
This parses the XML rosparam values into a list of (name, id)-tuples that can be sorted before the startup ping loop that checks the motors is started. This avoids confusion about the ping order (especially motor 19). Additionally, the name of the motor is also printed on ping errors.