### PR TITLE
ros_control: add option to read current servo PWM values

### DIFF
--- a/bitbots_ros_control/cfg/dynamixel_servo_hardware_interface_params.cfg
+++ b/bitbots_ros_control/cfg/dynamixel_servo_hardware_interface_params.cfg
@@ -16,6 +16,8 @@ gen.add("read_velocity", bool_t, 1,
         "Enable reading the current velocity values of the servos.")
 gen.add("read_effort", bool_t, 1,
         "Enable reading the current effort values of the servos.")
+gen.add("read_pwm", bool_t, 1,
+        "Enable reading the current PWM values of the servos.")
 gen.add("read_volt_temp", bool_t, 1,
         "Enable reading the current input voltages and temperature values of the servos.")
 gen.add("VT_update_rate", int_t, 1,

--- a/bitbots_ros_control/config/wolfgang.yaml
+++ b/bitbots_ros_control/config/wolfgang.yaml
@@ -17,6 +17,7 @@ ros_control:
     read_position: true
     read_velocity: false
     read_effort: false
+    read_pwm: false
     read_volt_temp: true # this also corresponds for the error byte
 
     VT_update_rate: 100 # how many normal (position) reads have to be performed before one time the temperature, voltage and error is read

--- a/bitbots_ros_control/include/bitbots_ros_control/dynamixel_servo_hardware_interface.h
+++ b/bitbots_ros_control/include/bitbots_ros_control/dynamixel_servo_hardware_interface.h
@@ -6,6 +6,7 @@
 
 #include <std_msgs/Bool.h>  
 #include <humanoid_league_msgs/Speak.h>
+#include <sensor_msgs/JointState.h>
 #include <diagnostic_msgs/DiagnosticStatus.h>
 #include <diagnostic_msgs/DiagnosticArray.h>
 #include <std_msgs/Bool.h>
@@ -98,6 +99,7 @@ private:
   bool syncReadPositions();
   bool syncReadVelocities();
   bool syncReadEfforts();
+  bool syncReadPWMs();
   bool syncReadAll();
   bool syncReadVoltageAndTemp();
   bool syncReadError();
@@ -146,10 +148,12 @@ private:
   bool read_position_;
   bool read_velocity_;
   bool read_effort_;
+  bool read_PWM_;
   bool read_volt_temp_;
   std::vector<double> current_position_;
   std::vector<double> current_velocity_;
   std::vector<double> current_effort_;
+  std::vector<double> current_pwm_;
   std::vector<double> current_input_voltage_;
   std::vector<double> current_temperature_;
   std::vector<uint8_t> current_error_;
@@ -166,6 +170,7 @@ private:
 
   // subscriber / publisher
   ros::Subscriber set_torque_sub_;
+  ros::Publisher pwm_pub_;
   ros::Publisher diagnostic_pub_;
   ros::Publisher speak_pub_;
   ros::Subscriber set_torque_indiv_sub_;

--- a/bitbots_ros_control/include/bitbots_ros_control/dynamixel_servo_hardware_interface.h
+++ b/bitbots_ros_control/include/bitbots_ros_control/dynamixel_servo_hardware_interface.h
@@ -148,7 +148,7 @@ private:
   bool read_position_;
   bool read_velocity_;
   bool read_effort_;
-  bool read_PWM_;
+  bool read_pwm_;
   bool read_volt_temp_;
   std::vector<double> current_position_;
   std::vector<double> current_velocity_;

--- a/bitbots_ros_control/package.xml
+++ b/bitbots_ros_control/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_ros_control</name>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
   <description>Hardware interface based the "dynamixel_workbench_ros_control" by Martin Oehler. It uses a modified version of the dynamixel_workbench to provide a higher update rate on the servo bus by using sync reads of multiple values. </description>
 
 

--- a/bitbots_ros_control/src/dynamixel_servo_hardware_interface.cpp
+++ b/bitbots_ros_control/src/dynamixel_servo_hardware_interface.cpp
@@ -149,7 +149,7 @@ bool DynamixelServoHardwareInterface::loadDynamixels(ros::NodeHandle& nh){
   nh.param("servos/read_position", read_position_, true);
   nh.param("servos/read_velocity", read_velocity_, false);
   nh.param("servos/read_effort", read_effort_, false);
-
+  nh.param("servos/read_pwm", read_pwm_, false);
 
   XmlRpc::XmlRpcValue dxls_xml;
   nh.getParam("servos/device_info", dxls_xml);
@@ -435,7 +435,7 @@ bool DynamixelServoHardwareInterface::read(){
       }
     }
 
-    if (read_PWM_) {
+    if (read_pwm_) {
       if (!syncReadPWMs()) {
         ROS_ERROR_THROTTLE(1.0, "Couldn't read current PWM!");
         driver_->reinitSyncReadHandler("Present_PWM");
@@ -709,7 +709,10 @@ bool DynamixelServoHardwareInterface::syncReadPWMs() {
     success = driver_->syncRead("Present_PWM", data);
     if(success){
       for (int i = 0; i < joint_count_; i++) {
-        current_pwm_[i] = data[i];
+        // the data is in int16
+        // 100% is a value of 885
+        // convert to range -1 to 1
+        current_pwm_[i] = ((int16_t)data[i]) / 885.0;
       }
     }
     free(data);
@@ -887,7 +890,7 @@ void DynamixelServoHardwareInterface::reconfCallback(bitbots_ros_control::dynami
   read_position_ = config.read_position;
   read_velocity_ = config.read_velocity;
   read_effort_ = config.read_effort;
-  read_PWM_ = config.read_pwm;
+  read_pwm_ = config.read_pwm;
   read_volt_temp_ = config.read_volt_temp;
   vt_update_rate_ = config.VT_update_rate;
   warn_temp_ = config.warn_temp;


### PR DESCRIPTION
## Proposed changes
add option to read the present PWM value from the servos. this helps debugging the problem of the servos not reaching their goal position, due to PID controller issues

## Related issues
-

## Necessary checks
- [x] Update package version
- [ ] Run linters
- [x] Run `catkin build`
- [ ] Write documentation
- [x] Test on your machine
- [x] Test on the robot

