### PR TITLE
ros_control: add interactive imu marker

### DIFF
--- a/bitbots_ros_control/config/controller.yaml
+++ b/bitbots_ros_control/config/controller.yaml
@@ -9,23 +9,4 @@ joint_state_controller:
 DynamixelController:
   type: bitbots_ros_control/DynamixelController
   joints:
-      - HeadPan
-      - HeadTilt
-      - LShoulderPitch
-      - LShoulderRoll
-      - LElbow
-      - RShoulderPitch
-      - RShoulderRoll
       - RElbow
-      - LHipYaw
-      - LHipRoll
-      - LHipPitch
-      - LKnee
-      - LAnklePitch
-      - LAnkleRoll
-      - RHipYaw
-      - RHipRoll
-      - RHipPitch
-      - RKnee
-      - RAnklePitch
-      - RAnkleRoll

--- a/bitbots_ros_control/config/controller.yaml
+++ b/bitbots_ros_control/config/controller.yaml
@@ -29,9 +29,3 @@ DynamixelController:
       - RKnee
       - RAnklePitch
       - RAnkleRoll
-
-    © 2019 GitHub, Inc.
-    Terms
-    Privacy
-    Security
-    Status

--- a/bitbots_ros_control/config/controller.yaml
+++ b/bitbots_ros_control/config/controller.yaml
@@ -9,4 +9,29 @@ joint_state_controller:
 DynamixelController:
   type: bitbots_ros_control/DynamixelController
   joints:
+      - HeadPan
+      - HeadTilt
+      - LShoulderPitch
+      - LShoulderRoll
+      - LElbow
+      - RShoulderPitch
+      - RShoulderRoll
       - RElbow
+      - LHipYaw
+      - LHipRoll
+      - LHipPitch
+      - LKnee
+      - LAnklePitch
+      - LAnkleRoll
+      - RHipYaw
+      - RHipRoll
+      - RHipPitch
+      - RKnee
+      - RAnklePitch
+      - RAnkleRoll
+
+    © 2019 GitHub, Inc.
+    Terms
+    Privacy
+    Security
+    Status

--- a/bitbots_ros_control/config/rviz_interactive_imu.rviz
+++ b/bitbots_ros_control/config/rviz_interactive_imu.rviz
@@ -1,0 +1,175 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /InteractiveMarkers1
+        - /Axes1
+      Splitter Ratio: 0.5
+    Tree Height: 828
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: false
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 100
+      Reference Frame: <Fixed Frame>
+      Value: false
+    - Alpha: 1
+      Class: rviz/RobotModel
+      Collision Enabled: false
+      Enabled: false
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+      Name: RobotModel
+      Robot Description: robot_description
+      TF Prefix: ""
+      Update Interval: 0
+      Value: false
+      Visual Enabled: true
+    - Class: rviz/TF
+      Enabled: false
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+      Marker Scale: 0.20000000298023224
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: false
+      Tree:
+        {}
+      Update Interval: 0
+      Value: false
+    - Class: rviz/Marker
+      Enabled: false
+      Marker Topic: visualization_marker
+      Name: Marker
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: false
+    - Class: rviz/InteractiveMarkers
+      Enable Transparency: true
+      Enabled: true
+      Name: InteractiveMarkers
+      Show Axes: true
+      Show Descriptions: true
+      Show Visual Aids: false
+      Update Topic: /interactive_imu/update
+      Value: true
+    - Class: rviz/Axes
+      Enabled: true
+      Length: 1
+      Name: Axes
+      Radius: 0.10000000149011612
+      Reference Frame: <Fixed Frame>
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: imu_frame
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/ThirdPersonFollower
+      Distance: 5.466794013977051
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: -0.25074559450149536
+        Y: 0.15042972564697266
+        Z: -0.4000089764595032
+      Focal Shape Fixed Size: false
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.2552035450935364
+      Target Frame: base_link
+      Value: ThirdPersonFollower (rviz)
+      Yaw: 1.6063202619552612
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1136
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd000000040000000000000268000003ccfc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005e00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000040000003cc000000ce00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000003ccfc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a005600690065007700730100000040000003cc000000ac00fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007800000003efc0100000002fb0000000800540069006d00650100000000000007800000025700fffffffb0000000800540069006d00650100000000000004500000000000000000000003fd000003cc00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1920
+  X: 1680
+  Y: 27

--- a/bitbots_ros_control/config/wolfgang.yaml
+++ b/bitbots_ros_control/config/wolfgang.yaml
@@ -1,9 +1,9 @@
 ros_control:
 
-  control_loop_hz: 1000
+  control_loop_hz: 10
 
   port_info:
-    port_name: /dev/ttyDXLBOARD
+    port_name: /dev/ttyACM0
     baudrate: 2000000
     protocol_version: 2
 
@@ -15,8 +15,8 @@ ros_control:
   servos:
     # specifies which information should be read
     read_position: true
-    read_velocity: false
-    read_effort: false
+    read_velocity: true
+    read_effort: true
     read_volt_temp: true # this also corresponds for the error byte
 
     VT_update_rate: 100 # how many normal (position) reads have to be performed before one time the temperature, voltage and error is read
@@ -53,64 +53,7 @@ ros_control:
       Feedforward_1st_Gain: 0 # [/4]
 
     device_info:
-      RShoulderPitch:
-        id: 1
-        model_number: 311
-      LShoulderPitch:
-        id: 2
-        model_number: 311
-      RShoulderRoll:
-        id: 3
-        model_number: 321
-      LShoulderRoll:
-        id: 4
-        model_number: 311
       RElbow:
         id: 5
         model_number: 321
-      LElbow:
-        id: 6
-        model_number: 311
-      RHipYaw:
-        id: 7
-        model_number: 321
-      LHipYaw:
-        id: 8
-        model_number: 321
-      RHipRoll:
-        id: 9
-        model_number: 321
-      LHipRoll:
-        id: 10
-        model_number: 321
-      RHipPitch:
-        id: 11
-        model_number: 321
-      LHipPitch:
-        id: 12
-        model_number: 321
-      RKnee:
-        id: 13
-        model_number: 321
-      LKnee:
-        id: 14
-        model_number: 321
-      RAnklePitch:
-        id: 15
-        model_number: 321
-      LAnklePitch:
-        id: 16
-        model_number: 321
-      RAnkleRoll:
-        id: 17
-        model_number: 321
-      LAnkleRoll:
-        id: 18
-        model_number: 321
-      HeadPan:
-        id: 19
-        model_number: 311
-      HeadTilt:
-        id: 20
-        model_number: 311
 

--- a/bitbots_ros_control/config/wolfgang.yaml
+++ b/bitbots_ros_control/config/wolfgang.yaml
@@ -1,9 +1,9 @@
 ros_control:
 
-  control_loop_hz: 10
+  control_loop_hz: 1000
 
   port_info:
-    port_name: /dev/ttyACM0
+    port_name: /dev/ttyDXLBOARD
     baudrate: 2000000
     protocol_version: 2
 
@@ -15,8 +15,8 @@ ros_control:
   servos:
     # specifies which information should be read
     read_position: true
-    read_velocity: true
-    read_effort: true
+    read_velocity: false
+    read_effort: false
     read_volt_temp: true # this also corresponds for the error byte
 
     VT_update_rate: 100 # how many normal (position) reads have to be performed before one time the temperature, voltage and error is read
@@ -53,7 +53,63 @@ ros_control:
       Feedforward_1st_Gain: 0 # [/4]
 
     device_info:
+      RShoulderPitch:
+        id: 1
+        model_number: 311
+      LShoulderPitch:
+        id: 2
+        model_number: 311
+      RShoulderRoll:
+        id: 3
+        model_number: 321
+      LShoulderRoll:
+        id: 4
+        model_number: 311
       RElbow:
         id: 5
         model_number: 321
-
+      LElbow:
+        id: 6
+        model_number: 311
+      RHipYaw:
+        id: 7
+        model_number: 321
+      LHipYaw:
+        id: 8
+        model_number: 321
+      RHipRoll:
+        id: 9
+        model_number: 321
+      LHipRoll:
+        id: 10
+        model_number: 321
+      RHipPitch:
+        id: 11
+        model_number: 321
+      LHipPitch:
+        id: 12
+        model_number: 321
+      RKnee:
+        id: 13
+        model_number: 321
+      LKnee:
+        id: 14
+        model_number: 321
+      RAnklePitch:
+        id: 15
+        model_number: 321
+      LAnklePitch:
+        id: 16
+        model_number: 321
+      RAnkleRoll:
+        id: 17
+        model_number: 321
+      LAnkleRoll:
+        id: 18
+        model_number: 321
+      HeadPan:
+        id: 19
+        model_number: 311
+      HeadTilt:
+        id: 20
+        model_number: 311

--- a/bitbots_ros_control/launch/rviz_interactive_imu.launch
+++ b/bitbots_ros_control/launch/rviz_interactive_imu.launch
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<launch>
+    <node pkg="rviz" type="rviz" args="-d $(find bitbots_ros_control)/config/rviz_interactive_imu.rviz" name="imu_rviz"/>
+    <node pkg="bitbots_ros_control" type="imu_interactive_marker.py" name="imu_interactive_marker" />
+</launch>

--- a/bitbots_ros_control/package.xml
+++ b/bitbots_ros_control/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_ros_control</name>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
   <description>Hardware interface based the "dynamixel_workbench_ros_control" by Martin Oehler. It uses a modified version of the dynamixel_workbench to provide a higher update rate on the servo bus by using sync reads of multiple values. </description>
 
 

--- a/bitbots_ros_control/scripts/imu_interactive_marker.py
+++ b/bitbots_ros_control/scripts/imu_interactive_marker.py
@@ -1,33 +1,5 @@
 #!/usr/bin/env python
 
-"""
-Copyright (c) 2011, Willow Garage, Inc.
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of the Willow Garage, Inc. nor the names of its
-      contributors may be used to endorse or promote products derived from
-      this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES LOSS OF USE, DATA, OR PROFITS OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
-"""
 import traceback
 
 import rospy
@@ -109,8 +81,8 @@ if __name__ == "__main__":
 
     server.applyChanges()
 
-    # create a timer to update the published ball transform
-    rospy.Timer(rospy.Duration(0.1), imu.publish_marker)
+    # create a timer to update the published imu transform
+    rospy.Timer(rospy.Duration(0.05), imu.publish_marker)
 
     # run and block until finished
     rospy.spin()

--- a/bitbots_ros_control/scripts/imu_interactive_marker.py
+++ b/bitbots_ros_control/scripts/imu_interactive_marker.py
@@ -13,13 +13,15 @@ from sensor_msgs.msg import Imu
 
 rospy.init_node("imu_interactive_marker")
 
-def normalizeQuaternion( quaternion_msg ):
-    norm = quaternion_msg.x**2 + quaternion_msg.y**2 + quaternion_msg.z**2 + quaternion_msg.w**2
-    s = norm**(-0.5)
+
+def normalize_quaternion(quaternion_msg):
+    norm = quaternion_msg.x ** 2 + quaternion_msg.y ** 2 + quaternion_msg.z ** 2 + quaternion_msg.w ** 2
+    s = norm ** (-0.5)
     quaternion_msg.x *= s
     quaternion_msg.y *= s
     quaternion_msg.z *= s
     quaternion_msg.w *= s
+
 
 class IMUMarker:
 
@@ -42,7 +44,7 @@ class IMUMarker:
         control.orientation.x = 1
         control.orientation.y = 0
         control.orientation.z = 0
-        normalizeQuaternion(control.orientation)
+        normalize_quaternion(control.orientation)
         control.name = "rotate_x"
         control.interaction_mode = InteractiveMarkerControl.ROTATE_AXIS
         control.always_visible = True
@@ -53,26 +55,25 @@ class IMUMarker:
         control.orientation.x = 0
         control.orientation.y = 0
         control.orientation.z = 1
-        normalizeQuaternion(control.orientation)
+        normalize_quaternion(control.orientation)
         control.name = "rotate_y"
         control.interaction_mode = InteractiveMarkerControl.ROTATE_AXIS
         int_marker.controls.append(control)
 
         # we want to use our special callback function
-        self.server.insert(int_marker, self.processFeedback)
+        self.server.insert(int_marker, self.process_feedback)
 
-    def processFeedback(self, feedback):
+    def process_feedback(self, feedback):
         self.pose = feedback.pose
 
     def publish_marker(self, e):
-        # create IMU message and publis
+        # create IMU message and publish
         imu_msg = Imu()
         imu_msg.header.stamp = rospy.get_rostime()
         imu_msg.header.frame_id = "imu"
         imu_msg.orientation = self.pose.orientation
 
         self.imu_publisher.publish(imu_msg)
-
 
 
 if __name__ == "__main__":

--- a/bitbots_ros_control/scripts/imu_interactive_marker.py
+++ b/bitbots_ros_control/scripts/imu_interactive_marker.py
@@ -79,15 +79,6 @@ class IMUMarker:
         control = InteractiveMarkerControl()
         control.orientation.w = 1
         control.orientation.x = 0
-        control.orientation.y = 1
-        control.orientation.z = 0
-        control.name = "rotate_z"
-        control.interaction_mode = InteractiveMarkerControl.ROTATE_AXIS
-        int_marker.controls.append(control)
-
-        control = InteractiveMarkerControl()
-        control.orientation.w = 1
-        control.orientation.x = 0
         control.orientation.y = 0
         control.orientation.z = 1
         control.name = "rotate_y"

--- a/bitbots_ros_control/scripts/imu_interactive_marker.py
+++ b/bitbots_ros_control/scripts/imu_interactive_marker.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+
+"""
+Copyright (c) 2011, Willow Garage, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Willow Garage, Inc. nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES LOSS OF USE, DATA, OR PROFITS OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+"""
+import traceback
+
+import rospy
+import copy
+import math
+
+from interactive_markers.interactive_marker_server import InteractiveMarkerServer
+from interactive_markers.menu_handler import MenuHandler
+from visualization_msgs.msg import InteractiveMarker, InteractiveMarkerControl, Marker
+from humanoid_league_msgs.msg import BallRelative, GoalRelative
+from geometry_msgs.msg import Pose, Point, Quaternion, Vector3
+from tf2_geometry_msgs import PointStamped
+from sensor_msgs.msg import Imu
+from tf.transformations import euler_from_quaternion
+import tf2_ros
+import numpy as np
+
+rospy.init_node("imu_interactive_marker")
+
+SIZE = 0.3
+
+
+class IMUMarker:
+
+    def __init__(self, server):
+        self.marker_name = "IMU"
+        self.imu_publisher = rospy.Publisher("/imu/data", Imu, queue_size=1)
+        self.server = server
+        self.pose = Pose()
+        self.pose.orientation.w = 1
+
+        int_marker = InteractiveMarker()
+        int_marker.header.frame_id = "imu_frame"
+        int_marker.pose = self.pose
+        int_marker.scale = 1
+        int_marker.name = self.marker_name
+        int_marker.description = "Rotate 3DOF to simulate IMU orientation"
+
+        control = InteractiveMarkerControl()
+        control.orientation.w = 1
+        control.orientation.x = 1
+        control.orientation.y = 0
+        control.orientation.z = 0
+        control.name = "rotate_x"
+        control.interaction_mode = InteractiveMarkerControl.ROTATE_AXIS
+        control.always_visible = True
+        int_marker.controls.append(control)
+
+        control = InteractiveMarkerControl()
+        control.orientation.w = 1
+        control.orientation.x = 0
+        control.orientation.y = 1
+        control.orientation.z = 0
+        control.name = "rotate_z"
+        control.interaction_mode = InteractiveMarkerControl.ROTATE_AXIS
+        int_marker.controls.append(control)
+
+        control = InteractiveMarkerControl()
+        control.orientation.w = 1
+        control.orientation.x = 0
+        control.orientation.y = 0
+        control.orientation.z = 1
+        control.name = "rotate_y"
+        control.interaction_mode = InteractiveMarkerControl.ROTATE_AXIS
+        int_marker.controls.append(control)
+
+        # we want to use our special callback function
+        self.server.insert(int_marker, self.processFeedback)
+
+    def processFeedback(self, feedback):
+        self.pose = feedback.pose
+
+    def publish_marker(self, e):
+        # create IMU message and publis
+        imu_msg = Imu()
+        imu_msg.header.stamp = rospy.get_rostime()
+        imu_msg.header.frame_id = "imu"
+        imu_msg.orientation = self.pose.orientation
+
+        self.imu_publisher.publish(imu_msg)
+
+
+
+if __name__ == "__main__":
+    server = InteractiveMarkerServer("interactive_imu")
+    imu = IMUMarker(server)
+
+    server.applyChanges()
+
+    # create a timer to update the published ball transform
+    rospy.Timer(rospy.Duration(0.1), imu.publish_marker)
+
+    # run and block until finished
+    rospy.spin()

--- a/bitbots_ros_control/scripts/imu_interactive_marker.py
+++ b/bitbots_ros_control/scripts/imu_interactive_marker.py
@@ -35,20 +35,19 @@ import copy
 import math
 
 from interactive_markers.interactive_marker_server import InteractiveMarkerServer
-from interactive_markers.menu_handler import MenuHandler
 from visualization_msgs.msg import InteractiveMarker, InteractiveMarkerControl, Marker
-from humanoid_league_msgs.msg import BallRelative, GoalRelative
 from geometry_msgs.msg import Pose, Point, Quaternion, Vector3
-from tf2_geometry_msgs import PointStamped
 from sensor_msgs.msg import Imu
-from tf.transformations import euler_from_quaternion
-import tf2_ros
-import numpy as np
 
 rospy.init_node("imu_interactive_marker")
 
-SIZE = 0.3
-
+def normalizeQuaternion( quaternion_msg ):
+    norm = quaternion_msg.x**2 + quaternion_msg.y**2 + quaternion_msg.z**2 + quaternion_msg.w**2
+    s = norm**(-0.5)
+    quaternion_msg.x *= s
+    quaternion_msg.y *= s
+    quaternion_msg.z *= s
+    quaternion_msg.w *= s
 
 class IMUMarker:
 
@@ -64,13 +63,14 @@ class IMUMarker:
         int_marker.pose = self.pose
         int_marker.scale = 1
         int_marker.name = self.marker_name
-        int_marker.description = "Rotate 3DOF to simulate IMU orientation"
+        int_marker.description = "Rotate 2DOF to simulate IMU orientation to ground"
 
         control = InteractiveMarkerControl()
         control.orientation.w = 1
         control.orientation.x = 1
         control.orientation.y = 0
         control.orientation.z = 0
+        normalizeQuaternion(control.orientation)
         control.name = "rotate_x"
         control.interaction_mode = InteractiveMarkerControl.ROTATE_AXIS
         control.always_visible = True
@@ -81,6 +81,7 @@ class IMUMarker:
         control.orientation.x = 0
         control.orientation.y = 0
         control.orientation.z = 1
+        normalizeQuaternion(control.orientation)
         control.name = "rotate_y"
         control.interaction_mode = InteractiveMarkerControl.ROTATE_AXIS
         int_marker.controls.append(control)

--- a/bitbots_ros_control/src/wolfgang_hardware_interface.cpp
+++ b/bitbots_ros_control/src/wolfgang_hardware_interface.cpp
@@ -41,7 +41,8 @@ WolfgangHardwareInterface::WolfgangHardwareInterface(ros::NodeHandle& nh){
 
   servos_ = DynamixelServoHardwareInterface(driver);
   imu_ = ImuHardwareInterface(driver);
-  right_foot_ = BitFootHardwareInterface(driver, 102, "/foot_pressure_right/raw");
+  left_foot_ = BitFootHardwareInterface(driver, 102, "/foot_pressure_left/raw");
+  right_foot_ = BitFootHardwareInterface(driver, 101, "/foot_pressure_right/raw");
   buttons_ = ButtonHardwareInterface(driver);
 
   // set the dynamic reconfigure and load standard params for servo interface
@@ -58,8 +59,8 @@ bool WolfgangHardwareInterface::init(ros::NodeHandle& root_nh){
     imu_.setParent(this);
     success &= imu_.init(root_nh);
   }else if(only_pressure_){
+    success &= left_foot_.init(root_nh);
     success &= right_foot_.init(root_nh);
-
   }else {
     /* Hardware interfaces must be registered at the main RobotHW class.
      * Therefore, a pointer to this class is passed down to the RobotHW classes
@@ -68,8 +69,8 @@ bool WolfgangHardwareInterface::init(ros::NodeHandle& root_nh){
     imu_.setParent(this);
     success &= servos_.init(root_nh);
     success &= imu_.init(root_nh);
+    success &= left_foot_.init(root_nh);
     success &= right_foot_.init(root_nh);
-
     success &= buttons_.init(root_nh);
   }
   if(success) {
@@ -87,13 +88,13 @@ bool WolfgangHardwareInterface::read()
   if(only_imu_){
     success &= imu_.read();
   }else if(only_pressure_){
+    success &= left_foot_.read();
     success &= right_foot_.read();
-
   }else{
     success &= servos_.read();
     success &= imu_.read();
+    success &= left_foot_.read();
     success &= right_foot_.read();
-
     success &= buttons_.read();
   }
   return success;

--- a/bitbots_ros_control/src/wolfgang_hardware_interface.cpp
+++ b/bitbots_ros_control/src/wolfgang_hardware_interface.cpp
@@ -41,8 +41,7 @@ WolfgangHardwareInterface::WolfgangHardwareInterface(ros::NodeHandle& nh){
 
   servos_ = DynamixelServoHardwareInterface(driver);
   imu_ = ImuHardwareInterface(driver);
-  left_foot_ = BitFootHardwareInterface(driver, 102, "/foot_pressure_left/raw");
-  right_foot_ = BitFootHardwareInterface(driver, 101, "/foot_pressure_right/raw");
+  right_foot_ = BitFootHardwareInterface(driver, 102, "/foot_pressure_right/raw");
   buttons_ = ButtonHardwareInterface(driver);
 
   // set the dynamic reconfigure and load standard params for servo interface
@@ -59,8 +58,8 @@ bool WolfgangHardwareInterface::init(ros::NodeHandle& root_nh){
     imu_.setParent(this);
     success &= imu_.init(root_nh);
   }else if(only_pressure_){
-    success &= left_foot_.init(root_nh);
     success &= right_foot_.init(root_nh);
+
   }else {
     /* Hardware interfaces must be registered at the main RobotHW class.
      * Therefore, a pointer to this class is passed down to the RobotHW classes
@@ -69,8 +68,8 @@ bool WolfgangHardwareInterface::init(ros::NodeHandle& root_nh){
     imu_.setParent(this);
     success &= servos_.init(root_nh);
     success &= imu_.init(root_nh);
-    success &= left_foot_.init(root_nh);
     success &= right_foot_.init(root_nh);
+
     success &= buttons_.init(root_nh);
   }
   if(success) {
@@ -88,13 +87,13 @@ bool WolfgangHardwareInterface::read()
   if(only_imu_){
     success &= imu_.read();
   }else if(only_pressure_){
-    success &= left_foot_.read();
     success &= right_foot_.read();
+
   }else{
     success &= servos_.read();
     success &= imu_.read();
-    success &= left_foot_.read();
     success &= right_foot_.read();
+
     success &= buttons_.read();
   }
   return success;


### PR DESCRIPTION
## Proposed changes
This adds a new launch file, which starts RViz with an interactive marker, that provides IMU orientation. It can be used for testing, instead of using a real IMU

## Related issues

## Necessary checks
- [x] Update package version
- [x] Run linters
- [x] Run `catkin build`
- [x] Write documentation
- [x] Test on your machine
- [x] Test on the robot

