### PR TITLE
ros_control: remove forgotten include

### DIFF
--- a/bitbots_ros_control/package.xml
+++ b/bitbots_ros_control/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_ros_control</name>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
   <description>Hardware interface based the "dynamixel_workbench_ros_control" by Martin Oehler. It uses a modified version of the dynamixel_workbench to provide a higher update rate on the servo bus by using sync reads of multiple values. </description>
 
 

--- a/bitbots_ros_control/src/node.cpp
+++ b/bitbots_ros_control/src/node.cpp
@@ -1,6 +1,5 @@
 #include <ros/callback_queue.h>
 #include <controller_manager/controller_manager.h>
-#include <bitbots_ros_control/bitbots_ros_control_paramsConfig.h>
 #include <bitbots_ros_control/wolfgang_hardware_interface.h>
 
 

--- a/bitbots_ros_control/src/pressure_converter.py
+++ b/bitbots_ros_control/src/pressure_converter.py
@@ -13,7 +13,6 @@ import rospkg
 import tf2_ros
 import os
 from dynamic_reconfigure.server import Server
-from bitbots_ros_control.cfg import bitbots_ros_control_paramsConfig
 
 
 class PressureConverter:


### PR DESCRIPTION
Remove the include of the file removed in #38.

## Necessary checks
- [x] Update package version
- [ ] Run linters
- [x] Run `catkin build`
- [ ] Write documentation
- [x] Test on your machine
- [x] Test on the robot

