### PR TITLE
ros_control: fix reading pwm value

### DIFF
--- a/bitbots_ros_control/package.xml
+++ b/bitbots_ros_control/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_ros_control</name>
-  <version>0.1.3</version>
+  <version>0.1.4</version>
   <description>Hardware interface based the "dynamixel_workbench_ros_control" by Martin Oehler. It uses a modified version of the dynamixel_workbench to provide a higher update rate on the servo bus by using sync reads of multiple values. </description>
 
 

--- a/bitbots_ros_control/src/dynamixel_servo_hardware_interface.cpp
+++ b/bitbots_ros_control/src/dynamixel_servo_hardware_interface.cpp
@@ -435,20 +435,19 @@ bool DynamixelServoHardwareInterface::read(){
       }
     }
 
-    if (read_pwm_) {
-      if (!syncReadPWMs()) {
-        ROS_ERROR_THROTTLE(1.0, "Couldn't read current PWM!");
-        driver_->reinitSyncReadHandler("Present_PWM");
-      }else{
-        sensor_msgs::JointState pwm_state = sensor_msgs::JointState();
-        pwm_state.header.stamp = ros::Time::now();
-        pwm_state.name = joint_names_;
-        pwm_state.effort = current_pwm_;
-        pwm_pub_.publish(pwm_state);
-      }
-    }
-    }
+  }
 
+  if (read_pwm_) {
+    if (!syncReadPWMs()) {
+      driver_->reinitSyncReadHandler("Present_PWM");
+    }else{
+      sensor_msgs::JointState pwm_state = sensor_msgs::JointState();
+      pwm_state.header.stamp = ros::Time::now();
+      pwm_state.name = joint_names_;
+      pwm_state.effort = current_pwm_;
+      pwm_pub_.publish(pwm_state);
+    }
+  }
 
   if (read_volt_temp_){
     if (read_vt_counter_ + 1 == vt_update_rate_){


### PR DESCRIPTION
Previously, the pwm value would not be read if position, velocity and effort are being read. 

## Proposed changes
move the check for reading pwm out of the else statement


## Necessary checks
- [x] Update package version
- [ ] Run linters
- [x] Run `catkin build`
- ~[ ] Write documentation~
- [x] Test on your machine
- [x] Test on the robot

