### PR TITLE
ros control: add launching system monitor

### DIFF
--- a/bitbots_ros_control/config/analyzers.yaml
+++ b/bitbots_ros_control/config/analyzers.yaml
@@ -31,3 +31,9 @@ analyzers:
     startswith: BUTTON
     timeout: 0.2
     find_and_remove_prefix: BUTTON
+  System:
+    type: diagnostic_aggregator/GenericAnalyzer
+    path: System
+    startswith: SYSTEM
+    timeout: 1
+    find_and_remove_prefix: SYSTEM

--- a/bitbots_ros_control/launch/ros_control.launch
+++ b/bitbots_ros_control/launch/ros_control.launch
@@ -27,6 +27,8 @@
 
     <node pkg="bitbots_ros_control" type="led_error_blink.py" name="error_blink"/>
 
+    <include file="$(find system_monitor)/launch/system_monitor.launch"/>
+
     <include file="$(find bitbots_buttons)/launch/buttons.launch"/>
 
     <include file="$(find humanoid_league_speaker)/launch/speaker.launch"/>

--- a/bitbots_ros_control/package.xml
+++ b/bitbots_ros_control/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_ros_control</name>
-  <version>2.0.3</version>
+  <version>2.1.0</version>
   <description>Hardware interface based the "dynamixel_workbench_ros_control" by Martin Oehler. It uses a modified version of the dynamixel_workbench to provide a higher update rate on the servo bus by using sync reads of multiple values. </description>
 
 


### PR DESCRIPTION
## Proposed changes
Launches the system monitor on start up and adds analysers for its diagnostic messages.

## Related issues
https://github.com/bit-bots/bitbots_misc/pull/79

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [x] Write documentation
- [x] Create issues for future work
- [x] Test on your machine
- [x] Test on the robot
- [x] Put the PR on our Project board

