### PR TITLE
ros control: fix bug in pressure converter

### DIFF
--- a/bitbots_ros_control/package.xml
+++ b/bitbots_ros_control/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_ros_control</name>
-  <version>2.0.3</version>
+  <version>2.0.4</version>
   <description>Hardware interface based the "dynamixel_workbench_ros_control" by Martin Oehler. It uses a modified version of the dynamixel_workbench to provide a higher update rate on the servo bus by using sync reads of multiple values. </description>
 
 

--- a/bitbots_ros_control/src/pressure_converter.cpp
+++ b/bitbots_ros_control/src/pressure_converter.cpp
@@ -91,7 +91,7 @@ void PressureConverter::pressureCallback(const bitbots_msgs::FootPressureConstPt
   current_index_ = (current_index_ + 1) % average_;
 
   filtered_msg.left_front = std::max(filtered_msg.left_front, 0.0);
-  filtered_msg.left_back = std::max(filtered_msg.left_front, 0.0);
+  filtered_msg.left_back = std::max(filtered_msg.left_back, 0.0);
   filtered_msg.right_front = std::max(filtered_msg.right_front, 0.0);
   filtered_msg.right_back = std::max(filtered_msg.right_back, 0.0);
 


### PR DESCRIPTION
## Proposed changes
just fixes a small bug which used two times the same value for the pressure sensor

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [x] Write documentation
- [x] Create issues for future work
- [ ] Test on your machine
- [x] Test on the robot
- [x] Put the PR on our Project board

