### PR TITLE
ros control: fix scheduling problems

### DIFF
--- a/bitbots_ros_control/config/wolfgang.yaml
+++ b/bitbots_ros_control/config/wolfgang.yaml
@@ -1,6 +1,6 @@
 ros_control:
 
-  control_loop_hz: 1000
+  control_loop_hz: 500
 
   port_info:
     port0:

--- a/bitbots_ros_control/launch/pressure_converter.launch
+++ b/bitbots_ros_control/launch/pressure_converter.launch
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <launch>
-    <node name="pressure_converter" pkg="bitbots_ros_control" type="pressure_converter">
+    <arg if="$(optenv IS_ROBOT false)" name="taskset" default="taskset -c 1"/>
+    <arg unless="$(optenv IS_ROBOT false)" name="taskset" default=""/>
+
+    <node name="pressure_converter" pkg="bitbots_ros_control" type="pressure_converter" launch-prefix="$(arg taskset)">
         <rosparam command="load" file="$(find bitbots_ros_control)/config/pressure_converter.yaml" />
         <rosparam command="load" file="$(find bitbots_ros_control)/config/pressure_$(optenv ROBOT_NAME nobot).yaml" />
     </node>

--- a/bitbots_ros_control/launch/ros_control.launch
+++ b/bitbots_ros_control/launch/ros_control.launch
@@ -6,6 +6,9 @@
     <arg name="only_imu" default="false"/>
     <arg name="only_pressure" default="false"/>
 
+    <arg if="$(optenv IS_ROBOT false)" name="taskset" default="taskset -c 0"/>
+    <arg unless="$(optenv IS_ROBOT false)" name="taskset" default=""/>
+
     <rosparam file="$(find bitbots_ros_control)/config/wolfgang.yaml" command="load" />
     <rosparam file="$(find bitbots_ros_control)/config/controller.yaml" command="load" />
 
@@ -14,7 +17,7 @@
     <param name="/ros_control/only_imu" value="$(arg only_imu)"/>
     <param name="/ros_control/only_pressure" value="$(arg only_pressure)"/>
 
-    <node pkg="bitbots_ros_control" type="node" name="ros_control" output="screen"/>
+    <node pkg="bitbots_ros_control" type="node" name="ros_control" output="screen" launch-prefix="$(arg taskset)"/>
 
     <group if="$(arg use_game_settings)">
         <rosparam command="load" file="$(find bitbots_bringup)/config/game_settings.yaml" />
@@ -37,7 +40,7 @@
 
     <node pkg="bitbots_ros_control" name="button_zero" type="zero_on_button.py"/>
 
-     <node pkg="bitbots_ros_control" name="battery_led" type="battery_led.py"/>
+    <node pkg="bitbots_ros_control" name="battery_led" type="battery_led.py"/>
 
 </launch>
 

--- a/bitbots_ros_control/package.xml
+++ b/bitbots_ros_control/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_ros_control</name>
-  <version>2.1.1</version>
+  <version>2.1.2</version>
   <description>Hardware interface based the "dynamixel_workbench_ros_control" by Martin Oehler. It uses a modified version of the dynamixel_workbench to provide a higher update rate on the servo bus by using sync reads of multiple values. </description>
 
 


### PR DESCRIPTION
## Proposed changes
Linux scheduling introduced problems when running full software stack. This PR limits the nodes to special cores via taskset, which solves the problem. Limited the control loop freq on 500Hz for now. Rather have it stable and a bit lower.

## Related issues
https://github.com/bit-bots/bitbots_lowlevel/issues/70

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [x] Write documentation
- [x] Create issues for future work
- [x] Test on your machine
- [x] Test on the robot
- [x] Put the PR on our Project board

