### PR TITLE
ros_control: disable accel calibration for normal users

### DIFF
--- a/bitbots_ros_control/src/imu_hardware_interface.cpp
+++ b/bitbots_ros_control/src/imu_hardware_interface.cpp
@@ -277,11 +277,13 @@ void ImuHardwareInterface::write(const ros::Time &t, const ros::Duration &dt) {
     write_complementary_filter_params_ = false;
   }
   if (calibrate_accel_) {
-    driver_->writeRegister(id_, "Calibrate_Accel", 1);
+    ROS_ERROR("Disabled for normal users for safety reasons, uncomment code to use");
+    //driver_->writeRegister(id_, "Calibrate_Accel", 1);
     calibrate_accel_ = false;
   }
   if (reset_accel_calibration_) {
-    driver_->writeRegister(id_, "Reset_Accel_Calibration", 1);
+    ROS_ERROR("Disabled for normal users for safety reasons, uncomment code to use");
+    //driver_->writeRegister(id_, "Reset_Accel_Calibration", 1);
     reset_accel_calibration_ = false;
   }
   if (set_accel_calib_threshold_) {


### PR DESCRIPTION
## Proposed changes
Accel calibration should only be used once at the beginning of an IMUs life-cycle.
While it is nice to have this in ros control, there is a great danger of inexperienced users breaking the calibration.
This PR disables it and the person calibration the imu has to uncomment one or two lines for the calibration.

## Necessary checks
- [ ] Update package version
- [x] Run `catkin build`
- [x] Write documentation (errors are printed)
- ~~[ ] Create issues for future work~~
- [] Test on your machine
- ~~[ ] Test on the robot~~
- [ ] Put the PR on our Project board

