### PR TITLE
control: make rate warning less sensitiv

### DIFF
--- a/bitbots_ros_control/config/analyzers.yaml
+++ b/bitbots_ros_control/config/analyzers.yaml
@@ -35,7 +35,7 @@ analyzers:
     type: diagnostic_aggregator/GenericAnalyzer
     path: Bus
     startswith: BUS
-    timeout: 0.1
+    timeout: 0.2
     find_and_remove_prefix: BUS
   System:
     type: diagnostic_aggregator/GenericAnalyzer

--- a/bitbots_ros_control/package.xml
+++ b/bitbots_ros_control/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_ros_control</name>
-  <version>2.2.2</version>
+  <version>2.2.3</version>
   <description>Hardware interface based the "dynamixel_workbench_ros_control" by Martin Oehler. It uses a modified version of the dynamixel_workbench to provide a higher update rate on the servo bus by using sync reads of multiple values. </description>
 
 

--- a/bitbots_ros_control/src/node.cpp
+++ b/bitbots_ros_control/src/node.cpp
@@ -90,9 +90,9 @@ int main(int argc, char *argv[]) {
 
     // publish diagnostic messages each 100 frames
     if (diag_counter % 100 == 0) {
-        // check if we are staying the correct cycle time. warning if more than 10% off
+        // check if we are staying the correct cycle time. warning if more than 50% off
         array_msg.header.stamp = ros::Time::now();
-        if(rate.cycleTime() < ros::Duration(1/control_loop_hz)*1.1){
+        if(rate.cycleTime() < ros::Duration(1/control_loop_hz)*1.5){
           status.level = diagnostic_msgs::DiagnosticStatus::OK;
           status.message = "";
         }else{

--- a/bitbots_ros_control/src/node.cpp
+++ b/bitbots_ros_control/src/node.cpp
@@ -90,9 +90,9 @@ int main(int argc, char *argv[]) {
 
     // publish diagnostic messages each 100 frames
     if (diag_counter % 100 == 0) {
-        // check if we are staying the correct cycle time. warning if more than 50% off
+        // check if we are staying the correct cycle time. warning if we only get half
         array_msg.header.stamp = ros::Time::now();
-        if(rate.cycleTime() < ros::Duration(1/control_loop_hz)*1.5){
+        if(rate.cycleTime() < ros::Duration(1/control_loop_hz)*2){
           status.level = diagnostic_msgs::DiagnosticStatus::OK;
           status.message = "";
         }else{


### PR DESCRIPTION
## Proposed changes
Warning was thrown to often for too small changes.

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [x] Write documentation
- [x] Create issues for future work
- [ ] Test on your machine
- [x] Test on the robot
- [x] Put the PR on our Project board

