### PR TITLE
control: fix imu filter params

### DIFF
--- a/bitbots_ros_control/config/wolfgang.yaml
+++ b/bitbots_ros_control/config/wolfgang.yaml
@@ -65,6 +65,12 @@ ros_control:
       Profile_Acceleration: 0 # 0 for infinite
       Profile_Velocity: 0 # 0 for infinite
 
+  imu:
+    do_adaptive_gain: False
+    do_bias_estimation: False
+    bias_alpha: 0.01
+    accel_gain: 0.001
+
   device_info:
     Core:
       id: 42

--- a/bitbots_ros_control/package.xml
+++ b/bitbots_ros_control/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_ros_control</name>
-  <version>2.2.3</version>
+  <version>2.2.4</version>
   <description>Hardware interface based the "dynamixel_workbench_ros_control" by Martin Oehler. It uses a modified version of the dynamixel_workbench to provide a higher update rate on the servo bus by using sync reads of multiple values. </description>
 
 

--- a/bitbots_ros_control/src/imu_hardware_interface.cpp
+++ b/bitbots_ros_control/src/imu_hardware_interface.cpp
@@ -76,18 +76,26 @@ bool ImuHardwareInterface::init(ros::NodeHandle &nh, ros::NodeHandle &hw_nh) {
   bitbots_msgs::AccelerometerCalibrationRequest req = bitbots_msgs::AccelerometerCalibrationRequest();
   bitbots_msgs::AccelerometerCalibrationResponse resp = bitbots_msgs::AccelerometerCalibrationResponse();
   readAccelCalibration(req, resp);
-  if (driver_->readMultipleRegisters(id_, 102, 14, data_)) {
+  if (driver_->readMultipleRegisters(id_, 102, 16, data_)) {
     gyro_range_ = data_[0];
     accel_range_ = data_[1];
     calibrate_gyro_ = data_[2];
     reset_gyro_calibration_ = data_[3];
-    do_adaptive_gain_ = data_[4];
-    do_bias_estimation_ = data_[5];
-    accel_gain_ = dxlMakeFloat(data_ + 6);
-    bias_alpha_ = dxlMakeFloat(data_ + 10);;
+    do_adaptive_gain_ = data_[6];
+    do_bias_estimation_ = data_[7];
+    accel_gain_ = dxlMakeFloat(data_ + 8);
+    bias_alpha_ = dxlMakeFloat(data_ + 12);
   } else {
     ROS_WARN("Could not read IMU %s config values in init", name_.c_str());
   }
+
+  //set filter values differently if specified in the confi and write them
+  do_adaptive_gain_ = nh.param("imu/do_adaptive_gain", do_adaptive_gain_);
+  do_bias_estimation_ = nh.param("imu/do_bias_estimation", do_bias_estimation_);
+  accel_gain_ = nh.param("imu/accel_gain", accel_gain_);
+  bias_alpha_ = nh.param("imu/accel_gain", bias_alpha_);
+  write_complementary_filter_params_ = true;
+  write(ros::Time(0), ros::Duration(0));
 
   return true;
 }


### PR DESCRIPTION
## Proposed changes
IMU firmware has small bug and does not remember one parameter. This will set them on start from config if defined. Will also generally be a nice thing

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [x] Write documentation
- [x] Create issues for future work
- [ ] Test on your machine
- [x] Test on the robot
- [x] Put the PR on our Project board

