### PR TITLE
ros_control: fix overload message

### DIFF
--- a/bitbots_ros_control/src/servo_bus_interface.cpp
+++ b/bitbots_ros_control/src/servo_bus_interface.cpp
@@ -456,7 +456,7 @@ void ServoBusInterface::processVte(bool success) {
         // turn off torque on all motors
         // todo should also turn off power, but is not possible yet
         goal_torque_ = false;
-        ROS_ERROR("OVERLOAD ERROR!!! OVERLOAD ERROR!!! OVERLOAD ERROR!!! In Motor %d", i);
+        ROS_ERROR("OVERLOAD ERROR!!! OVERLOAD ERROR!!! OVERLOAD ERROR!!! In Motor %s", joint_names_[i].c_str());
         speakError(speak_pub_, "Overload Error!");
       }
     }


### PR DESCRIPTION
## Proposed changes
Currently the overload message just printed an index of an array instead of the correct servo id. It is now changed to its name, as this is more convenient. 

## Related issues

## Necessary checks
- [ ] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

