### PR TITLE
Use -Wall in ros_control

### DIFF
--- a/bitbots_ros_control/CMakeLists.txt
+++ b/bitbots_ros_control/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(bitbots_ros_control)
 set(CMAKE_CXX_STANDARD 17)
+add_compile_options(-Wall -Werror -Wno-unused)
 
 find_package(catkin REQUIRED COMPONENTS
         roscpp

--- a/bitbots_ros_control/src/bitfoot_hardware_interface.cpp
+++ b/bitbots_ros_control/src/bitfoot_hardware_interface.cpp
@@ -77,7 +77,7 @@ void BitFootHardwareInterface::read(const ros::Time &t, const ros::Duration &dt)
 
       bool okay = false;
       double last = 0;
-      for (int j = 0; j < current_pressure_[i].size(); j++) {
+      for (size_t j = 0; j < current_pressure_[i].size(); j++) {
         if (last != current_pressure_[0][j]) {
           okay = true;
           break;

--- a/bitbots_ros_control/src/dynamixel_servo_hardware_interface.cpp
+++ b/bitbots_ros_control/src/dynamixel_servo_hardware_interface.cpp
@@ -121,9 +121,9 @@ void DynamixelServoHardwareInterface::individualTorqueCb(bitbots_msgs::JointTorq
   }
 
   // we save the goal torque value. It will be set during write process
-  for (int i = 0; i < msg.joint_names.size(); i++) {
+  for (size_t i = 0; i < msg.joint_names.size(); i++) {
     bool success = false;
-    for (int j = 0; j < joint_names_.size(); j++) {
+    for (size_t j = 0; j < joint_names_.size(); j++) {
       if (msg.joint_names[i] == joint_names_[j]) {
         if (i < msg.joint_names.size()) {
           goal_torque_individual_[j] = msg.on[i];
@@ -149,7 +149,7 @@ void DynamixelServoHardwareInterface::setTorqueCb(std_msgs::BoolConstPtr enabled
   for (ServoBusInterface *bus: bus_interfaces_) {
     bus->goal_torque_ = enabled->data;
   }
-  for (int j = 0; j < joint_names_.size(); j++) {
+  for (size_t j = 0; j < joint_names_.size(); j++) {
     goal_torque_individual_[j] = enabled->data;
   }
 }

--- a/bitbots_ros_control/src/leds_hardware_interface.cpp
+++ b/bitbots_ros_control/src/leds_hardware_interface.cpp
@@ -77,7 +77,7 @@ bool LedsHardwareInterface::setLeds(bitbots_msgs::LedsRequest &req, bitbots_msgs
     return false;
   }
 
-  for (int i = 0; i < leds_.size(); i++) {
+  for (size_t i = 0; i < leds_.size(); i++) {
     // return current state of LEDs
     resp.previous_leds.push_back(leds_[i]);
 

--- a/bitbots_ros_control/src/pressure_converter.cpp
+++ b/bitbots_ros_control/src/pressure_converter.cpp
@@ -160,7 +160,7 @@ void PressureConverter::resetZeroAndScaleValues() {
 
 void PressureConverter::collectMessages() {
   save_zero_and_scale_values_ = true;
-  while (zero_and_scale_values_[0].size() < scale_and_zero_average_) {
+  while (int(zero_and_scale_values_[0].size()) < scale_and_zero_average_) {
     ROS_WARN_THROTTLE(0.25, "%ld of %d msgs", zero_and_scale_values_[0].size(), scale_and_zero_average_);
     ros::spinOnce();
   }

--- a/bitbots_ros_control/src/servo_bus_interface.cpp
+++ b/bitbots_ros_control/src/servo_bus_interface.cpp
@@ -81,6 +81,7 @@ bool ServoBusInterface::init(ros::NodeHandle &nh, ros::NodeHandle &hw_nh) {
     }
   }
   writeTorque(nh.param("servos/auto_torque", false));
+  return true;
 }
 
 ServoBusInterface::~ServoBusInterface(){
@@ -242,7 +243,7 @@ void ServoBusInterface::read(const ros::Time &t, const ros::Duration &dt) {
     // when the servos have a goal position which is not the current position on startup
     // they will rapidly move to this position, possibly damaging the robot
     // therefore the goal position is set to the current position of the motors
-    for (int i = 0; i < current_position_.size(); i++) {
+    for (size_t i = 0; i < current_position_.size(); i++) {
       goal_position_[i] = current_position_[i];
     }
     first_cycle_ = false;
@@ -407,7 +408,7 @@ void ServoBusInterface::processVte(bool success) {
   std::vector<diagnostic_msgs::DiagnosticStatus> array = std::vector<diagnostic_msgs::DiagnosticStatus>();
   array_msg.header.stamp = ros::Time::now();
 
-  for (int i = 0; i < joint_names_.size(); i++) {
+  for (size_t i = 0; i < joint_names_.size(); i++) {
     char level = diagnostic_msgs::DiagnosticStatus::OK;
     std::string message = "OK";
     std::map<std::string, std::string> map;


### PR DESCRIPTION
## Proposed changes
This adds the -Wall -Werror -Wno-unused flags to ros_controll.

## Related issues

## Necessary checks
- [x] Run `catkin build`
~- [ ] Write documentation~
~- [ ] Create issues for future work~
~- [ ] Test on your machine~
- [ ] Test on the robot
- [x] Put the PR on our Project board

