### PR TITLE
ros control: fix missing head imu and wrong imu topic

### DIFF
--- a/bitbots_ros_control/config/wolfgang.yaml
+++ b/bitbots_ros_control/config/wolfgang.yaml
@@ -101,6 +101,12 @@ wolfgang_hardware_interface:
         interface_type: LED
         number_of_LEDs: 3
         start_number: 3
+      IMU_head:
+        id: 241
+        topic: imu_head/data
+        frame: imu_head_frame
+        model_number: 0xBAFF
+        interface_type: IMU
       RShoulderPitch:
         id: 1
         model_number: 311

--- a/bitbots_ros_control/config/wolfgang.yaml
+++ b/bitbots_ros_control/config/wolfgang.yaml
@@ -102,7 +102,7 @@ wolfgang_hardware_interface:
         number_of_LEDs: 3
         start_number: 3
       IMU_head:
-        id: 241
+        id: 242
         topic: imu_head/data
         frame: imu_head_frame
         model_number: 0xBAFF

--- a/bitbots_ros_control/src/imu_hardware_interface.cpp
+++ b/bitbots_ros_control/src/imu_hardware_interface.cpp
@@ -64,7 +64,7 @@ bool ImuHardwareInterface::init() {
   set_accel_calib_threshold_service_ = nh_->create_service<bitbots_msgs::srv::SetAccelerometerCalibrationThreshold>(
       "/imu/set_accel_calibration_threshold", std::bind(&ImuHardwareInterface::setAccelCalibrationThreshold, this, _1, _2));
 
-  imu_pub_ = nh_->create_publisher<sensor_msgs::msg::Imu>("/imu/data", 10);
+  imu_pub_ = nh_->create_publisher<sensor_msgs::msg::Imu>(topic_, 10);
   diagnostic_pub_ = nh_->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 10);
 
   // read the current values in the IMU module so that they can later be displayed in diagnostic message


### PR DESCRIPTION
## Proposed changes
Head IMU was missing in config and therefore not read. Additionally, the imu topic was hardcoded instead of using the parameters.


## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

