### PR TITLE
Fix torqueless mode parameter

### DIFF
--- a/bitbots_ros_control/src/servo_bus_interface.cpp
+++ b/bitbots_ros_control/src/servo_bus_interface.cpp
@@ -22,8 +22,7 @@ bool ServoBusInterface::init() {
   reading_successes_ = 0;
   reading_errors_ = 0;
 
-  rclcpp::Parameter torqueless_parameter = rclcpp::Parameter("torqueless_mode", false);
-  torqueless_mode_ = nh_->get_parameter_or("torqueless_mode", torqueless_parameter, rclcpp::Parameter("torqueless_mode", false));
+  torqueless_mode_ = nh_->get_parameter("torqueless_mode").as_bool();
   read_volt_temp_  = nh_->get_parameter("servos.read_volt_temp").as_bool();
   vt_update_rate_  = nh_->get_parameter("servos.VT_update_rate").as_int();
   warn_volt_ = nh_->get_parameter("servos.warn_volt").as_double();


### PR DESCRIPTION
## Proposed changes
Changes read of torqueless_mode parameter back, as get_parameter_or does not seem to work as intended. This also means, the parameter needs to be set in every launch file and no longer has a default value.

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Necessary checks
- [ ] Update package version
- [x] Run ~~catkin~~ `colcon build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [x] Test on the robot
- [ ] Put the PR on our Project board

