### PR TITLE
Disable head IMU as it might not be reliable

### DIFF
--- a/bitbots_ros_control/config/wolfgang.yaml
+++ b/bitbots_ros_control/config/wolfgang.yaml
@@ -101,12 +101,6 @@ wolfgang_hardware_interface:
         interface_type: LED
         number_of_LEDs: 3
         start_number: 3
-      IMU_head:
-        id: 242
-        topic: imu_head/data
-        frame: imu_head_frame
-        model_number: 0xBAFF
-        interface_type: IMU
       RShoulderPitch:
         id: 1
         model_number: 311


### PR DESCRIPTION
We had problems with the head imu on Donna, maybe it broke during a fall. As it is not used anywhere, it can be disabled.