### PR TITLE
Rename ros_control node from "node" to "ros_control"

### DIFF
--- a/bitbots_ros_control/CMakeLists.txt
+++ b/bitbots_ros_control/CMakeLists.txt
@@ -50,8 +50,8 @@ set(SOURCES
 
 enable_bitbots_docs()
 
-add_executable(node ${SOURCES})
-ament_target_dependencies(node
+add_executable(ros_control ${SOURCES})
+ament_target_dependencies(ros_control
         ament_cmake
         backward_ros
         bitbots_buttons
@@ -113,7 +113,7 @@ ament_export_dependencies(std_msgs)
 ament_export_dependencies(tf2_ros)
 ament_export_dependencies(transmission_interface)
 
-install(TARGETS node
+install(TARGETS ros_control
         DESTINATION lib/${PROJECT_NAME})
 install(TARGETS pressure_converter
         DESTINATION lib/${PROJECT_NAME})

--- a/bitbots_ros_control/launch/ros_control.launch
+++ b/bitbots_ros_control/launch/ros_control.launch
@@ -8,7 +8,7 @@
     <let if="$(env IS_ROBOT false)" name="taskset" value="taskset -c 0"/>
     <let unless="$(env IS_ROBOT false)" name="taskset" value=""/>
 
-    <node pkg="bitbots_ros_control" exec="node" output="screen" launch-prefix="$(var taskset)">
+    <node pkg="bitbots_ros_control" exec="ros_control" output="screen" launch-prefix="$(var taskset)">
         <param from="$(find-pkg-share bitbots_ros_control)/config/wolfgang.yaml" />
         <param name="torqueless_mode" value="$(var torqueless_mode)"/>
         <param name="only_imu" value="$(var only_imu)"/>


### PR DESCRIPTION
## Proposed changes
Currently the ros_control node is listed as "node" in the logs. This is not very helpful.

## Necessary checks
- [ ] Update package version
- [x] Run `colcon build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

