### PR TITLE
Fix write of power status to CORE

### DIFF
--- a/bitbots_ros_control/include/bitbots_ros_control/core_hardware_interface.h
+++ b/bitbots_ros_control/include/bitbots_ros_control/core_hardware_interface.h
@@ -44,8 +44,10 @@ class CoreHardwareInterface : public bitbots_ros_control::HardwareInterface{
   int read_counter_;
   uint8_t *data_;
 
-  bool requested_power_switch_status_;
+  bool requested_power_status_;
+  bool last_read_successful_;
   std_msgs::msg::Bool power_switch_status_;
+  std_msgs::msg::Bool power_control_status_;
   std_msgs::msg::Float64 VCC_;
   std_msgs::msg::Float64 VBAT_;
   std_msgs::msg::Float64MultiArray VBAT_individual_;

--- a/bitbots_ros_control/src/core_hardware_interface.cpp
+++ b/bitbots_ros_control/src/core_hardware_interface.cpp
@@ -9,19 +9,14 @@ CoreHardwareInterface::CoreHardwareInterface(rclcpp::Node::SharedPtr nh, std::sh
   id_ = id;
   read_rate_ = read_rate;
   read_counter_ = 0;
-  requested_power_switch_status_ = true;
+  requested_power_status_ = true;
   power_switch_status_.data = false;
-
-  power_switch_status_ = std_msgs::msg::Bool();
-  VCC_ = std_msgs::msg::Float64();
-  VBAT_ = std_msgs::msg::Float64();
-  VEXT_ = std_msgs::msg::Float64();
-  VDXL_ = std_msgs::msg::Float64();
-  current_ = std_msgs::msg::Float64();
+  power_control_status_.data = false;
+  last_read_successful_ = false;
 }
 
 bool CoreHardwareInterface::switch_power(std::shared_ptr<std_srvs::srv::SetBool::Request> req, std::shared_ptr<std_srvs::srv::SetBool::Response> resp) {
-  requested_power_switch_status_ = req->data;
+  requested_power_status_ = req->data;
   // wait for main loop to set value
   resp->success = true;
   return true;
@@ -51,7 +46,8 @@ bool CoreHardwareInterface::init() {
 }
 
 bool CoreHardwareInterface::get_power_status(){
-  return power_switch_status_.data;
+  // this is only true when the physical switch and the soft status are true
+  return power_control_status_.data && power_switch_status_.data;
 }
 
 void CoreHardwareInterface::read(const rclcpp::Time &t, const rclcpp::Duration &dt) {
@@ -62,30 +58,31 @@ void CoreHardwareInterface::read(const rclcpp::Time &t, const rclcpp::Duration &
   if (read_counter_ % read_rate_ == 0) {
     read_counter_ = 0;
     // read core
-    bool read_successful = true;
-    if (driver_->readMultipleRegisters(id_, 28, 22, data_)) {
+    last_read_successful_ = true;
+    if (driver_->readMultipleRegisters(id_, 23, 27, data_)) {
       // we read one string of bytes. see CORE firmware for definition of registers
       // convert to volt
-      VEXT_.data = (((float) dxlMakeword(data_[0], data_[1])) * (3.3 / 1024)) * 6;
-      VCC_.data = (((float) dxlMakeword(data_[2], data_[3])) * (3.3 / 1024)) * 6;
-      VDXL_.data = (((float) dxlMakeword(data_[4], data_[5])) * (3.3 / 1024)) * 6;
+      power_control_status_.data = data_[0];
+      VEXT_.data = (((float) dxlMakeword(data_[5], data_[6])) * (3.3 / 1024)) * 6;
+      VCC_.data = (((float) dxlMakeword(data_[7], data_[8])) * (3.3 / 1024)) * 6;
+      VDXL_.data = (((float) dxlMakeword(data_[9], data_[10])) * (3.3 / 1024)) * 6;
       // convert to ampere. first go to voltage by 1024*3.3. shift by 2.5 and mulitply by volt/ampere
-      current_.data = ((((float) dxlMakeword(data_[6], data_[7])) * (3.3 / 1024)) - 2.5) / -0.066;
+      current_.data = ((((float) dxlMakeword(data_[11], data_[12])) * (3.3 / 1024)) - 2.5) / -0.066;
       // we need to apply a threshold on this to see if power is on or off
-      power_switch_status_.data = dxlMakeword(data_[8], data_[9]);
+      power_switch_status_.data = dxlMakeword(data_[13], data_[14]);
       // calculate cell voltages as voltages read * voltage divider ratio - previous cell voltage sum
-      VBAT_individual_.data[0] = ((float) dxlMakeword(data_[10], data_[11])) * (3.3 / 1024) * (3.3 / (1.2 + 3.3));
+      VBAT_individual_.data[0] = ((float) dxlMakeword(data_[15], data_[16])) * (3.3 / 1024) * (3.3 / (1.2 + 3.3));
       VBAT_individual_.data[1] =
-          ((float) dxlMakeword(data_[12], data_[13])) * (3.3 / 1024) * (3.6 / (6.2 + 3.6)) - VBAT_individual_.data[0];
+          ((float) dxlMakeword(data_[17], data_[18])) * (3.3 / 1024) * (3.6 / (6.2 + 3.6)) - VBAT_individual_.data[0];
       VBAT_individual_.data[2] =
-          ((float) dxlMakeword(data_[14], data_[15])) * (3.3 / 1024) * (2.2 / (6.8 + 2.2)) - VBAT_individual_.data[1];
+          ((float) dxlMakeword(data_[19], data_[20])) * (3.3 / 1024) * (2.2 / (6.8 + 2.2)) - VBAT_individual_.data[1];
       VBAT_individual_.data[3] =
-          ((float) dxlMakeword(data_[16], data_[17])) * (3.3 / 1024) * (3.6 / (16.0 + 3.6)) - VBAT_individual_.data[2];
+          ((float) dxlMakeword(data_[21], data_[22])) * (3.3 / 1024) * (3.6 / (16.0 + 3.6)) - VBAT_individual_.data[2];
       VBAT_individual_.data[4] =
-          ((float) dxlMakeword(data_[18], data_[19])) * (3.3 / 1024) * (6.2 / (36.0 + 6.2)) - VBAT_individual_.data[3];
+          ((float) dxlMakeword(data_[23], data_[24])) * (3.3 / 1024) * (6.2 / (36.0 + 6.2)) - VBAT_individual_.data[3];
       VBAT_individual_.data[5] =
-          ((float) dxlMakeword(data_[20], data_[21])) * (3.3 / 1024) * (1.8 / (13.0 + 1.8)) - VBAT_individual_.data[4];
-      VBAT_.data = ((float) dxlMakeword(data_[20], data_[21])) * (3.3 / 1024) * (1.8 / (13.0 + 1.8));
+          ((float) dxlMakeword(data_[25], data_[26])) * (3.3 / 1024) * (1.8 / (13.0 + 1.8)) - VBAT_individual_.data[4];
+      VBAT_.data = ((float) dxlMakeword(data_[25], data_[26])) * (3.3 / 1024) * (1.8 / (13.0 + 1.8));
 
       power_pub_->publish(power_switch_status_);
       vcc_pub_->publish(VCC_);
@@ -96,7 +93,7 @@ void CoreHardwareInterface::read(const rclcpp::Time &t, const rclcpp::Duration &
       current_pub_->publish(current_);
     } else {
       RCLCPP_ERROR_THROTTLE(nh_->get_logger(), *nh_->get_clock(), 3000, "Could not read CORE sensor");
-      read_successful = false;
+      last_read_successful_ = false;
     }
 
     // diagnostics. check if values are changing, otherwise there is a connection error on the board
@@ -114,13 +111,18 @@ void CoreHardwareInterface::read(const rclcpp::Time &t, const rclcpp::Duration &
     } else {
       map.insert(std::make_pair("power_switch_status", "OFF"));
     }
+    if (power_control_status_.data) {
+      map.insert(std::make_pair("power_control_status", "ON"));
+    } else {
+      map.insert(std::make_pair("power_control_status", "OFF"));
+    }
     map.insert(std::make_pair("VCC", std::to_string(VCC_.data)));
     map.insert(std::make_pair("VBAT", std::to_string(VBAT_.data)));
     map.insert(std::make_pair("VEXT", std::to_string(VEXT_.data)));
     map.insert(std::make_pair("VDXL", std::to_string(VDXL_.data)));
     map.insert(std::make_pair("Current", std::to_string(current_.data)));
 
-    if (read_successful) {
+    if (last_read_successful_) {
       status.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
       status.message = "OK";
     } else {
@@ -145,8 +147,9 @@ void CoreHardwareInterface::read(const rclcpp::Time &t, const rclcpp::Duration &
 
 void CoreHardwareInterface::write(const rclcpp::Time &t, const rclcpp::Duration &dt) {
   // we only need to write something if requested power status and current power status do not match
-  if (requested_power_switch_status_ != power_switch_status_.data) {
-    driver_->writeRegister(id_, "Power", requested_power_switch_status_);
+  // we don't use power_switch_status here because we cannot overwrite the physical switch
+  if (requested_power_status_ != power_control_status_.data && last_read_successful_) {
+    driver_->writeRegister(id_, "Power", requested_power_status_);
   }
 }
 }


### PR DESCRIPTION
## Proposed changes
This PR changes some things in the power status handling of ros_control. First of all, we now also read the "soft" power switch (software-controlled) status instead of only the physical switch. This data is also used to determine whether we should change the power status because we cannot change the physical power switch anyway. In addition, the CORE board is only written when it was read successfully. This resolves a `stack smashing detected` error we encountered when the CORE board was not available but we tried to write its registers.

## Necessary checks
- [x] Run `colcon build`
- [x] Write documentation
- [x] Test on the robot
- [x] Put the PR on our Project board

