### PR TITLE
remove reading of velocity and current as it is currently not used

### DIFF
--- a/bitbots_ros_control/config/wolfgang.yaml
+++ b/bitbots_ros_control/config/wolfgang.yaml
@@ -24,8 +24,8 @@ wolfgang_hardware_interface:
     servos:
       # specifies which information should be read
       read_position: true
-      read_velocity: true
-      read_effort: true
+      read_velocity: false
+      read_effort: false
       read_pwm: false
       read_volt_temp: true # this also corresponds for the error byte
 


### PR DESCRIPTION
## Proposed changes
Stop reading velocity and current as we do not use them in software.
